### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png-achunk"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cpg314/png-achunk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,19 +4,19 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cpg314/png-achunk"
-category = ["multimedia::images"]
 description = "Encode and decode custom binary chunks in PNG images "
+categories = ["multimedia::images"]
 
 [dependencies]
 ascii = "1.1.0"
-crc32fast = "1.3.2"
-image = "0.24.7"
-png = "0.17.10"
-thiserror = "1.0.50"
+crc32fast = "1.5.0"
+image = "0.25.6"
+png = "0.17.16"
+thiserror = "2.0.12"
 
 [dev-dependencies]
-tempfile = "3.8.1"
-anyhow = "1.0.75"
+tempfile = "3.20.0"
+anyhow = "1.0.98"
 
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Only a primitive interface is implemented at the moment.
 
 The example in `c/test.c` can be compiled with
 
-```
+```bash
 $ gcc test.c -L. -l:libpng_achunk.a -lm -o test
 ```
 

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/c/src/lib.rs
+++ b/c/src/lib.rs
@@ -12,7 +12,7 @@ fn read_chunk_impl(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn read_chunk(
+unsafe extern "C" fn read_chunk(
     filename: *const std::ffi::c_char,
     name: *const std::ffi::c_char,
     ptr: *mut *mut u8,
@@ -37,7 +37,7 @@ pub unsafe extern "C" fn read_chunk(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn free_chunk(ptr: *mut u8, len: *const libc::size_t) {
+unsafe extern "C" fn free_chunk(ptr: *mut u8, len: *const libc::size_t) {
     let len = len as usize;
     drop(Vec::<u8>::from_raw_parts(ptr, len, len));
 }

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -1,4 +1,4 @@
-use std::io::{Cursor, Read, Seek};
+use std::io::{BufRead, Cursor, Seek};
 use std::path::PathBuf;
 
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyBytes, types::PyString};
@@ -26,7 +26,7 @@ fn read_chunk<'a>(
     read_chunk_from_decoder(py, decoder, name)
 }
 
-fn read_chunk_from_decoder<'a, R: Read + Seek>(
+fn read_chunk_from_decoder<'a, R: BufRead + Seek>(
     py: Python<'a>,
     mut decoder: png_achunk::Decoder<R>,
     name: &'a PyString,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.81"

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,4 +1,4 @@
-use std::io::{BufReader, Read, Seek};
+use std::io::{BufRead, BufReader, Seek};
 use std::path::Path;
 
 use crate::chunk::{self, Chunk};
@@ -22,10 +22,10 @@ pub enum DecodingError {
 }
 
 /// PNG decoding, including ancillary chunks.
-pub struct Decoder<R: Read + Seek> {
+pub struct Decoder<R: BufRead + Seek> {
     reader: R,
 }
-impl<R: Read + Seek> Decoder<R> {
+impl<R: BufRead + Seek> Decoder<R> {
     pub fn from_reader(reader: R) -> Self {
         Self { reader }
     }
@@ -38,7 +38,7 @@ impl Decoder<BufReader<std::fs::File>> {
         Ok(Self::from_reader(reader))
     }
 }
-impl<R: Read + Seek> Decoder<R> {
+impl<R: BufRead + Seek> Decoder<R> {
     /// Decode the non-critical chunks only, without reading the full image if they are placed before
     /// the IDAT section.
     pub fn decode_ancillary_chunks(&mut self) -> Result<Vec<Chunk>, DecodingError> {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -37,6 +37,7 @@ impl Encoder<std::io::BufWriter<std::fs::File>> {
         let output = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(output)?;
         let output = std::io::BufWriter::new(output);
         Ok(Self::new(output))
@@ -57,22 +58,24 @@ impl<W: Write> image::ImageEncoder for Encoder<W> {
         buf: &[u8],
         width: u32,
         height: u32,
-        color_type: image::ColorType,
+        color_type: image::ExtendedColorType,
     ) -> image::ImageResult<()> {
         let (ct, bits) = match color_type {
-            image::ColorType::L8 => (png::ColorType::Grayscale, png::BitDepth::Eight),
-            image::ColorType::L16 => (png::ColorType::Grayscale, png::BitDepth::Sixteen),
-            image::ColorType::La8 => (png::ColorType::GrayscaleAlpha, png::BitDepth::Eight),
-            image::ColorType::La16 => (png::ColorType::GrayscaleAlpha, png::BitDepth::Sixteen),
-            image::ColorType::Rgb8 => (png::ColorType::Rgb, png::BitDepth::Eight),
-            image::ColorType::Rgb16 => (png::ColorType::Rgb, png::BitDepth::Sixteen),
-            image::ColorType::Rgba8 => (png::ColorType::Rgba, png::BitDepth::Eight),
-            image::ColorType::Rgba16 => (png::ColorType::Rgba, png::BitDepth::Sixteen),
+            image::ExtendedColorType::L8 => (png::ColorType::Grayscale, png::BitDepth::Eight),
+            image::ExtendedColorType::L16 => (png::ColorType::Grayscale, png::BitDepth::Sixteen),
+            image::ExtendedColorType::La8 => (png::ColorType::GrayscaleAlpha, png::BitDepth::Eight),
+            image::ExtendedColorType::La16 => {
+                (png::ColorType::GrayscaleAlpha, png::BitDepth::Sixteen)
+            }
+            image::ExtendedColorType::Rgb8 => (png::ColorType::Rgb, png::BitDepth::Eight),
+            image::ExtendedColorType::Rgb16 => (png::ColorType::Rgb, png::BitDepth::Sixteen),
+            image::ExtendedColorType::Rgba8 => (png::ColorType::Rgba, png::BitDepth::Eight),
+            image::ExtendedColorType::Rgba16 => (png::ColorType::Rgba, png::BitDepth::Sixteen),
             _ => {
                 return Err(image::ImageError::Unsupported(
                     image::error::UnsupportedError::from_format_and_kind(
                         image::ImageFormat::Png.into(),
-                        image::error::UnsupportedErrorKind::Color(color_type.into()),
+                        image::error::UnsupportedErrorKind::Color(color_type),
                     ),
                 ))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+// Avoid code examples in README.md to be compiled when running doctests.
+#![cfg(not(doctest))]
 #![doc = include_str!("../README.md")]
 
 mod chunk;


### PR DESCRIPTION
The goal is to depend on the latest `image` crate.

This required depending on a newer Rust toolchain.

Tested:
```
$ cargo build -r --workspace
$ cargo test -r --workspace
$ cargo clippy --workspace
```

```
$ cd c
$ nm -g -C ../target/release/libpng_achunk_c.a 2>/dev/null | grep " T " | grep -v :  | grep _chunk 
0000000000000000 T free_chunk
0000000000000000 T read_chunk
$ gcc test.c -L../target/release -lpng_achunk_c
$ ./a.out 
4
5
6
```

```
$ cp target/release/libpng_achunk_py.so png_achunk.so
$ python3 -c 'import png_achunk; print(png_achunk.read_chunk("/tmp/test.png", "teST"))'
b'\x04\x05\x06'
```